### PR TITLE
configure logger with encoding and formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY:
 .SILENT:
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := compile
 
 lint:
 	golangci-lint run
@@ -11,10 +11,10 @@ test:
 cover: test
 	go tool cover -func=cover.out
 
-build:
+compile:
 	go mod download && CGO_ENABLED=0 GOOS=linux go build -o app ./cmd/main.go
 
-run: build
+run: compile
 	./app
 
 fmt:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,6 +24,7 @@ func Run(configPath string) {
 		return
 	}
 
+	//nolint:errcheck
 	//goland:noinspection GoUnhandledErrorResult
 	defer log.Sync()
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mebr0/squirrel-bot/internal/config"
 	"github.com/mebr0/squirrel-bot/internal/telegram"
 	"github.com/mebr0/squirrel-bot/pkg/logging"
-	"go.uber.org/zap"
 	"os"
 	"os/signal"
 	"syscall"
@@ -25,12 +24,8 @@ func Run(configPath string) {
 		return
 	}
 
-	defer func(log *zap.Logger) {
-		err := log.Sync()
-		if err != nil {
-			log.Warn("error during flushing entries - " + err.Error())
-		}
-	}(log)
+	//goland:noinspection GoUnhandledErrorResult
+	defer log.Sync()
 
 	botApi, err := tgbotapi.NewBotAPI(cfg.Telegram.BotToken)
 

--- a/pkg/logging/zap.go
+++ b/pkg/logging/zap.go
@@ -14,6 +14,24 @@ func NewLogger(levelString string) (*zap.Logger, error) {
 
 	cfg := zap.Config{
 		Level: zap.NewAtomicLevelAt(level),
+		DisableStacktrace: true,
+		Encoding: "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "T",
+			LevelKey:       "L",
+			NameKey:        "N",
+			CallerKey:      "C",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "M",
+			StacktraceKey:  "S",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
 	}
 
 	logger, err := cfg.Build()
@@ -24,3 +42,4 @@ func NewLogger(levelString string) (*zap.Logger, error) {
 
 	return logger, nil
 }
+


### PR DESCRIPTION
+ fix Makefile with renaming build command to compile, because build command with dependencies reference to `build` directory